### PR TITLE
add -nologs parameter

### DIFF
--- a/tarkas/arma3/public/tacticalrealism1.json
+++ b/tarkas/arma3/public/tacticalrealism1.json
@@ -5,7 +5,7 @@
             "SERVER_NAME": "tacticalrealism1",
             "IP_ADDRESS": "144.217.11.41",
             "PORT": "2302",
-            "PARAMETERS": "-noSound",
+            "PARAMETERS": "-noSound -noLogs",
             "STEAM_BASE_PATH": "D:\\steam\\",
             "STEAM_WORKSHOP_PATH": "steamapps\\workshop\\content\\107410\\",
             "STORE_PATH": "D:\\store\\arma3\\",


### PR DESCRIPTION
tactical realism 1 is set with logging enabled.
for performance reasons, we should not be leaving this enabled unless absolutely needed.