### PR TITLE
Update tacticalrealism2.json

### DIFF
--- a/tarkas/arma3/public/tacticalrealism2.json
+++ b/tarkas/arma3/public/tacticalrealism2.json
@@ -84,6 +84,26 @@
                 "name": "@DynaSound2",
                 "server": "true"
             },
+			{
+                "app": "861133494",
+                "name": "@JSRS",
+                "server": "true"
+            },
+			{
+                "app": "1180533757",
+                "name": "@JSRSUSAF",
+                "server": "true"
+            },
+			{
+                "app": "945476727",
+                "name": "@JSRSAFRF",
+                "server": "true"
+            },
+			{
+                "app": "1180534892",
+                "name": "@JSRSGREF",
+                "server": "true"
+            },
             {
                 "app": "",
                 "name": "@CavMetrics",


### PR DESCRIPTION
Unknown why the tac 2 mods do not seem to be listed and are replaced with: 
                "app": "767380317",
                "name": "@BCESA",
                "server": "true"
            },
            {
                "app": "853303947",
                "name": "@BCESA_VS",
                "server": "true"

If it works though, it works.

ADDING:
- JSRS Soundmods back to tac 2 per Tharen & Jarvis request.
