### PR TITLE
Set Lambs_Danger FSM to Optional Mod

### DIFF
--- a/tarkas/arma3/training/training1.json
+++ b/tarkas/arma3/training/training1.json
@@ -164,7 +164,7 @@
     {
       "app": "1858075458",
       "name": "@LMBS_DGR",
-      "server": "false"
+      "server": "true"
     },
     {
       "app": "1926513010",

--- a/tarkas/arma3/training/training2.json
+++ b/tarkas/arma3/training/training2.json
@@ -164,7 +164,7 @@
     {
       "app": "1858075458",
       "name": "@LMBS_DGR",
-      "server": "false"
+      "server": "true"
     },
     {
       "app": "1926513010",

--- a/tarkas/arma3/training/training3.json
+++ b/tarkas/arma3/training/training3.json
@@ -164,7 +164,7 @@
     {
       "app": "1858075458",
       "name": "@LMBS_DGR",
-      "server": "false"
+      "server": "true"
     },
     {
       "app": "1926513010",

--- a/tarkas/arma3/training/training4.json
+++ b/tarkas/arma3/training/training4.json
@@ -164,7 +164,7 @@
     {
       "app": "1858075458",
       "name": "@LMBS_DGR",
-      "server": "false"
+      "server": "true"
     },
     {
       "app": "1926513010",


### PR DESCRIPTION
Issue with players having to validate signatures for a optional mod.

As per developer:  "Only Server and Zeus, or anyone handling AI (Like Headless Clients) need to have it running."

This push request will change the mod to be loaded as a servermod.
This will allow players to join with or without the mod loaded, and leave it as an optional.